### PR TITLE
Bug fix: Let transform work with std::vector as ReturnType

### DIFF
--- a/src/bits/transform.h
+++ b/src/bits/transform.h
@@ -70,7 +70,7 @@ auto transformed(InputContainer &&input, Transform &&transform)
                                            std::forward<Transform>(transform));
 }
 
-template <template <typename> class ResultContainer, typename InputContainer, typename Transform>
+template <template <typename...> class ResultContainer, typename InputContainer, typename Transform>
 #if __cplusplus < 201703L
 using ResultTypeForTransformed =
     ResultContainer<typename std::result_of<Transform(ValueType<InputContainer>)>::type>;
@@ -80,7 +80,7 @@ using ResultTypeForTransformed =
     ResultContainer<std::invoke_result_t<Transform, ValueType<InputContainer>>>;
 #endif
 
-template <template <typename> class ResultContainer, typename InputContainer, typename Transform>
+template <template <typename...> class ResultContainer, typename InputContainer, typename Transform>
 auto transformed(InputContainer &&input, Transform &&transform)
 {
     return detail::transformed<

--- a/tests/tst_KDAlgorithms.cpp
+++ b/tests/tst_KDAlgorithms.cpp
@@ -60,6 +60,7 @@ private Q_SLOTS:
     void transformedChangeContainer();
     void transformedSameContainer();
     void transformedChangeContainerAndDataType();
+    void transformedChangeContainerAndDataType2();
     void transformedChangeDataType();
     void transformedWithRValue();
     void transform();
@@ -242,6 +243,15 @@ void TestAlgorithms::transformedChangeContainerAndDataType()
 {
     auto result = KDAlgorithms::transformed<QVector>(intVector, toString);
     QVector<QString> expected{"1", "2", "3", "4"};
+    QCOMPARE(result, expected);
+}
+
+void TestAlgorithms::transformedChangeContainerAndDataType2()
+{
+    QVector<int> vec{1, 2, 3, 4};
+    const auto toString = [](int i) { return QString::number(i); };
+    auto result = KDAlgorithms::transformed<std::vector>(vec, toString);
+    std::vector<QString> expected{"1", "2", "3", "4"};
     QCOMPARE(result, expected);
 }
 


### PR DESCRIPTION
As so often before the problem was that std::vector is actually a
template of two arguments.