### PR TITLE
Prevent single_arg_inserter being used for std::set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(BUILD_TESTING AND ${KDALGORITHMS_BUILD_TEST})
     add_compile_options(-Wall)
 
     if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Werror -Wno-deprecated -Wextra -Woverloaded-virtual -Winit-self -Wmissing-include-dirs -Wunused -Wno-div-by-zero -Werror=undef -Wpointer-arith -Wmissing-noreturn -Werror=return-type -Wsuggest-override")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Werror -Wno-deprecated -Wextra -Woverloaded-virtual -Winit-self -Wmissing-include-dirs -Wunused -Wno-div-by-zero -Werror=undef -Wpointer-arith -Wmissing-noreturn -Werror=return-type")
     endif()
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -36,7 +36,6 @@ if(BUILD_TESTING AND ${KDALGORITHMS_BUILD_TEST})
     if(MSVC) # Check if we are using the Visual Studio compiler
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus") # Make __cplusplus match the actual C++ version used
     endif()
-
 
     # Needed for the unit tests
     find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Widgets REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(BUILD_TESTING AND ${KDALGORITHMS_BUILD_TEST})
     add_compile_options(-Wall)
 
     if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Werror -Wno-deprecated -Wextra -Woverloaded-virtual -Winit-self -Wmissing-include-dirs -Wunused -Wno-div-by-zero -Werror=undef -Wpointer-arith -Wmissing-noreturn -Werror=return-type")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wno-deprecated -Wextra -Woverloaded-virtual -Winit-self -Wmissing-include-dirs -Wunused -Wno-div-by-zero -Werror=undef -Wpointer-arith -Wmissing-noreturn -Werror=return-type")
     endif()
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Lots of Examples
 In this document you will find lots of examples. More, however, may be found in the 
 unit tests.
 
+Qt
+--
+kdalgorihms supports all of Qt's containers, with the exception that with Qt5 QSet isn't supported.
+
 Algorithms
 ==========
 

--- a/src/bits/insert_wrapper.h
+++ b/src/bits/insert_wrapper.h
@@ -16,34 +16,11 @@
 
 namespace kdalgorithms {
 namespace detail {
-    // similar to std::inserter, but calls insert with just one argument - required for QSet in Qt5
-    template <typename T>
-    class single_arg_inserter
-    {
-    public:
-        using value_type = typename T::value_type;
-        single_arg_inserter(T &set)
-            : m_set(&set)
-        {
-        }
-
-        single_arg_inserter &operator++() { return *this; }
-        single_arg_inserter &operator*() { return *this; }
-        single_arg_inserter &operator=(const value_type &value)
-        {
-            m_set->insert(value);
-            return *this;
-        }
-
-    private:
-        T *m_set;
-    };
-
     template <class Container, typename T>
     using has_push_back = decltype(std::declval<Container &>().push_back(std::declval<T>()));
 
-    template <class Container, typename T>
-    using has_insert = decltype(std::declval<Container &>().insert(std::declval<T>()));
+    template <class Container, typename Value>
+    using has_insert = decltype(std::declval<Container &>().insert(std::declval<Value>()));
 
     template <typename Container>
     auto insert_wrapper(
@@ -61,7 +38,7 @@ namespace detail {
         std::enable_if_t<
             detail::is_detected_v<has_insert, Container, typename Container::value_type>, int> = 0)
     {
-        return single_arg_inserter<Container>(c);
+        return std::inserter<Container>(c, c.end());
     }
 
     // similar to std::inserter, but for QMap/QHash which usually accept a value in their operator=

--- a/src/bits/insert_wrapper.h
+++ b/src/bits/insert_wrapper.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "method_tests.h"
+#include "shared.h"
 #include <iterator>
 #include <utility>
 
@@ -46,6 +47,12 @@ namespace detail {
     class qmap_inserter
     {
     public:
+        using iterator_category = std::output_iterator_tag;
+        using value_type = ValueType<T>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = value_type *;
+        using reference = value_type &;
+
         qmap_inserter(T &map)
             : m_map(map)
         {

--- a/src/bits/insert_wrapper.h
+++ b/src/bits/insert_wrapper.h
@@ -53,7 +53,7 @@ namespace detail {
         using pointer = value_type *;
         using reference = value_type &;
 
-        qmap_inserter(T &map)
+        qmap_inserter(T *map)
             : m_map(map)
         {
         }
@@ -63,19 +63,19 @@ namespace detail {
         qmap_inserter &
         operator=(const std::pair<typename T::key_type, typename T::mapped_type> &pair)
         {
-            m_map.insert(pair.first, pair.second);
+            m_map->insert(pair.first, pair.second);
             return *this;
         }
 
     private:
-        T &m_map;
+        T *m_map;
     };
 
     template <typename Container>
     auto insert_wrapper(Container &c,
                         std::enable_if_t<detail::has_keyValueBegin_v<Container>, int> = 0)
     {
-        return qmap_inserter<Container>(c);
+        return qmap_inserter<Container>(&c);
     }
 
 } // namespace detail

--- a/src/bits/transform.h
+++ b/src/bits/transform.h
@@ -65,7 +65,7 @@ namespace detail {
     {
         std::transform(std::begin(input), std::end(input), std::begin(input),
                        std::forward<Transform>(transform));
-        return input;
+        return std::forward(input);
     }
 
     template <typename ResultContainer, typename InputContainer, typename Transform>

--- a/tests/tst_kdalgorithms.cpp
+++ b/tests/tst_kdalgorithms.cpp
@@ -747,10 +747,10 @@ void TestAlgorithms::sortWithCompare()
     }
 
     {
-        std::vector<Struct> structVec{{1, 3}, {3, 4}, {3, 2}, {1, 2}};
-        kdalgorithms::sort(structVec, &Struct::lessThanByXY);
+        std::vector<Struct> vec{{1, 3}, {3, 4}, {3, 2}, {1, 2}};
+        kdalgorithms::sort(vec, &Struct::lessThanByXY);
         std::vector<Struct> expected{{1, 2}, {1, 3}, {3, 2}, {3, 4}};
-        QCOMPARE(structVec, expected);
+        QCOMPARE(vec, expected);
     }
 }
 
@@ -764,8 +764,8 @@ void TestAlgorithms::sortedWithCompare()
     }
 
     {
-        std::vector<Struct> structVec{{1, 3}, {3, 4}, {3, 2}, {1, 2}};
-        auto result = kdalgorithms::sorted(structVec, &Struct::lessThanByXY);
+        std::vector<Struct> vec{{1, 3}, {3, 4}, {3, 2}, {1, 2}};
+        auto result = kdalgorithms::sorted(vec, &Struct::lessThanByXY);
         std::vector<Struct> expected{{1, 2}, {1, 3}, {3, 2}, {3, 4}};
         QCOMPARE(result, expected);
     }
@@ -1199,20 +1199,22 @@ void TestAlgorithms::get_match_or_default()
 {
     auto withKey = [](int key) { return [key](const Struct &s) { return s.key == key; }; };
 
-    auto value = kdalgorithms::get_match_or_default(structVec, withKey(2));
-    Struct expected{2, 3};
-    QCOMPARE(value, expected);
+    {
+        auto value = kdalgorithms::get_match_or_default(structVec, withKey(2));
+        Struct expected{2, 3};
+        QCOMPARE(value, expected);
 
-    value = kdalgorithms::get_match_or_default(structVec, withKey(-1));
-    QCOMPARE(value, Struct{});
+        value = kdalgorithms::get_match_or_default(structVec, withKey(-1));
+        QCOMPARE(value, Struct{});
 
-    Struct defaultValue{42, -42};
-    value = kdalgorithms::get_match_or_default(structVec, withKey(-1), defaultValue);
-    QCOMPARE(value, defaultValue);
+        Struct defaultValue{42, -42};
+        value = kdalgorithms::get_match_or_default(structVec, withKey(-1), defaultValue);
+        QCOMPARE(value, defaultValue);
 
-    value =
-        kdalgorithms::get_match_or_default(structVec, &Struct::hasEqualKeyValuePair, defaultValue);
-    QCOMPARE(value, defaultValue);
+        value = kdalgorithms::get_match_or_default(structVec, &Struct::hasEqualKeyValuePair,
+                                                   defaultValue);
+        QCOMPARE(value, defaultValue);
+    }
 
     {
         std::map<int, int> map{{1, 2}, {2, 1}, {13, 3}, {4, 1}};

--- a/tests/tst_kdalgorithms.cpp
+++ b/tests/tst_kdalgorithms.cpp
@@ -240,10 +240,12 @@ void TestAlgorithms::copy()
 
     // QSet
     {
+#if QT_VERSION >= 0x060000
         QSet<int> from{1, 2, 3, 4, 1, 3};
         QSet<int> to;
         kdalgorithms::copy(from, to);
         QCOMPARE(from, to);
+#endif
     }
 
     // QMap
@@ -369,9 +371,11 @@ void TestAlgorithms::filterOtherContainers()
     }
 
     {
+#if QT_VERSION >= 0x060000
         auto result = kdalgorithms::filtered<QSet>(intVector, isOdd);
         QSet<int> expected{1, 3};
         QCOMPARE(result, expected);
+#endif
     }
 
     {
@@ -529,9 +533,11 @@ void TestAlgorithms::transformOtherContainers()
     }
 
     {
+#if QT_VERSION >= 0x060000
         auto result = kdalgorithms::transformed<QSet>(intVector, toString);
         QSet<QString> expected{"1", "2", "3", "4"};
         QCOMPARE(result, expected);
+#endif
     }
 
     // This unfortunately doesn't work as I have no way to deduce the result type of the transform


### PR DESCRIPTION
The single_arg_inserter failed to work with std::set in GCC 9