### PR TITLE
Add alias target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ if(POLICY CMP0077) # Yes, let the parent project set BUILD_TESTING before we inc
 endif()
 
 add_library(kdalgorithms INTERFACE)
-target_include_directories(kdalgorithms INTERFACE src/)
 add_library(KDAB::KDAlgorithms ALIAS kdalgorithms)
+target_include_directories(kdalgorithms INTERFACE src/)
 
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 add_library(kdalgorithms INTERFACE)
 target_include_directories(kdalgorithms INTERFACE src/)
+add_library(KDAB::KDAlgorithms ALIAS kdalgorithms)
 
 include(CTest)
 


### PR DESCRIPTION
This gives much nicer error reporting at configure time for downstream applications as CMake knows that KDAB::KDAlgorithms is a target, whereas kdalgorithms may be a target or a library which the build system does not know about until build time.