### PR TITLE
Use Container::size_type to kill warning in Qt5

### DIFF
--- a/src/bits/reserve_helper.h
+++ b/src/bits/reserve_helper.h
@@ -17,13 +17,14 @@
 namespace kdalgorithms {
 namespace detail {
     template <typename Container>
-    bool reserve_helper(Container & /*container*/, size_t /*size*/, std::false_type)
+    bool reserve_helper(Container & /*container*/, typename Container::size_type /*size*/,
+                        std::false_type)
     {
         return false;
     }
 
     template <typename Container>
-    bool reserve_helper(Container &container, size_t size, std::true_type)
+    bool reserve_helper(Container &container, typename Container::size_type size, std::true_type)
     {
         container.reserve(size);
         return true;
@@ -32,7 +33,7 @@ namespace detail {
     template <typename Container>
     // call reserve on the container if it supports the operation
     // return if operation was supported.
-    bool reserve(Container &container, size_t size)
+    bool reserve(Container &container, typename Container::size_type size)
     {
         return reserve_helper(container, size,
                               std::integral_constant<bool, has_reserve_method_v<Container>>());


### PR DESCRIPTION
Hopefully silence #44 