### PR TITLE
Expose /Zc:__cplusplus flag to consumers of the kdalgorithm target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(kdalgorithms INTERFACE)
 add_library(KDAB::KDAlgorithms ALIAS kdalgorithms)
 target_include_directories(kdalgorithms INTERFACE src/)
 
+if(MSVC)
+    target_compile_options(kdalgorithms INTERFACE /Zc:__cplusplus)
+endif()
+
 include(CTest)
 
 if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)


### PR DESCRIPTION
Until now MSVC users would have __cplusplus disabled by default and their builds could fail.

~Fixes #43.~