### PR TITLE
Improved sort_by

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(BUILD_TESTING AND ${KDALGORITHMS_BUILD_TEST})
         src/bits/transform.h
         src/bits/zip.h
         src/bits/tuple_utils.h
+        src/bits/invoke.h
 
         tests/tst_kdalgorithms.cpp
         tests/tst_constraints.cpp

--- a/Documentation/algorithms.md
+++ b/Documentation/algorithms.md
@@ -249,7 +249,7 @@ See [std::sort](https://en.cppreference.com/w/cpp/algorithm/sort) for the algori
 <a name="sort_by">sort_by / sorted_by</a>
 ------------------------------------------
 **sort** may take a second parameter, which is the predicate for sorting. 
-However, in many situations you simply have a container of struct and want to sort it, by one of the members of the struct.
+However, in many situations you simply have a container of struct, and want to sort it by one of the members of the struct.
 This is exactly what **sort_by** does.
 
 ```
@@ -263,7 +263,36 @@ kdalgorithms::sort_by(people, &Person::age);
 // people == {{"Jane", 20}, {"John", 25}, {"Bob", 27}}
 ```
 
-**sorted_by** returns a sorted copy of the container provided.
+As an alternative to specifying a member variable you may specify a member function:
+
+```
+std::vector<std::string> list{"John", "James", "Bob"};
+kdalgorithms::sort_by(list, &std::string::length);
+// list = Bob, John, James
+```
+
+You may also specify an extraction function as the second parameter:
+
+```
+std::map<std::string, int> scores{{"John", 25}, {"Jane", 20}, {"Bob", 27}};
+std::vector<std::string> list{"John", "Jane", "Bob"};
+auto score = [&](const std::string &name) { return scores[name]; };
+kdalgorithms::sort_by(list, score);
+
+list = Jane, John, Bob
+```
+
+### sort order
+The sort order may be specified for sort_by, using a third argument:
+
+```
+std::vector<Struct> vec{{1, 3}, {3, 4}, {3, 2}, {1, 2}};
+kdalgorithms::sort_by(vec, &Struct::value, kdalgorithms::descending);
+// vec = {3, 4}, {1, 3}, {3, 2}, {1, 2}
+```
+
+**sorted_by** is similar to sort_by, except that it returns a sorted copy of the container provided.
+
 
 <a name="is_sorted">is_sorted</a>
 ---------------------------------

--- a/src/bits/invoke.h
+++ b/src/bits/invoke.h
@@ -1,0 +1,76 @@
+/* MIT License
+
+Copyright (C) 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#pragma once
+#include <functional>
+
+namespace kdalgorithms {
+namespace detail {
+    template <typename Function, typename Object, typename DontCare1, typename DontCare2,
+              typename... Args>
+    decltype(auto) invoke_helper(Function function, Object &&object, std::false_type, DontCare1,
+                                 DontCare2, Args &&...args)
+    {
+        return function(object, std::forward<Args>(args)...);
+    }
+
+    template <typename Member, typename Object, typename... Args>
+    decltype(auto) invoke_helper(Member member, Object &&object, std::true_type, std::true_type,
+                                 std::true_type, Args &&...args)
+    {
+        return (object->*member)(std::forward<Args>(args)...);
+    }
+
+    template <typename Member, typename Object>
+    decltype(auto) invoke_helper(Member member, Object &&object, std::true_type, std::false_type,
+                                 std::true_type)
+    {
+        return object->*member;
+    }
+
+    template <typename Member, typename Object, typename... Args>
+    decltype(auto) invoke_helper(Member member, Object &&object, std::true_type, std::true_type,
+                                 std::false_type, Args &&...args)
+    {
+        return (object.*member)(std::forward<Args>(args)...);
+    }
+
+    template <typename Member, typename Object>
+    decltype(auto) invoke_helper(Member member, Object &&object, std::true_type, std::false_type,
+                                 std::false_type)
+    {
+        return object.*member;
+    }
+
+    template <typename Function, typename Object, typename... Args>
+    decltype(auto) invoke(Function function, Object &&object, Args &&...args)
+    {
+        using Type = std::remove_reference_t<Object>;
+        return invoke_helper(function, std::forward<Object>(object),
+                             std::is_member_pointer<Function>(),
+                             std::is_member_function_pointer<Function>(), std::is_pointer<Type>(),
+                             std::forward<Args>(args)...);
+    }
+
+} // namespace detail
+} // kdalgorithms

--- a/src/bits/invoke.h
+++ b/src/bits/invoke.h
@@ -1,25 +1,12 @@
-/* MIT License
-
-Copyright (C) 2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-*/
+/****************************************************************************
+**
+** This file is part of KDAlgorithms
+**
+** SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+**
+** SPDX-License-Identifier: MIT
+**
+****************************************************************************/
 
 #pragma once
 #include <functional>

--- a/src/bits/invoke.h
+++ b/src/bits/invoke.h
@@ -28,38 +28,46 @@ namespace kdalgorithms {
 namespace detail {
     template <typename Function, typename Object, typename DontCare1, typename DontCare2,
               typename... Args>
-    decltype(auto) invoke_helper(Function function, Object &&object, std::false_type, DontCare1,
-                                 DontCare2, Args &&...args)
+    decltype(auto) invoke_helper(Function function, Object &&object,
+                                 std::false_type /* is member pointer*/, DontCare1, DontCare2,
+                                 Args &&...args)
     {
         return function(object, std::forward<Args>(args)...);
     }
 
     template <typename Member, typename Object, typename... Args>
-    decltype(auto) invoke_helper(Member member, Object &&object, std::true_type, std::true_type,
-                                 std::true_type, Args &&...args)
+    decltype(auto) invoke_helper(Member member, Object &&object,
+                                 std::true_type /* is member pointer */,
+                                 std::true_type /* is member function */,
+                                 std::true_type /* is object a pointer */, Args &&...args)
     {
-        return (object->*member)(std::forward<Args>(args)...);
+        return (std::forward<Object>(object)->*member)(std::forward<Args>(args)...);
     }
 
     template <typename Member, typename Object>
-    decltype(auto) invoke_helper(Member member, Object &&object, std::true_type, std::false_type,
-                                 std::true_type)
+    decltype(auto)
+    invoke_helper(Member member, Object &&object, std::true_type /* is member pointer */,
+                  std::false_type /* is member function */, std::true_type /* is object a pointer*/)
     {
-        return object->*member;
+        return std::forward<Object>(object)->*member;
     }
 
     template <typename Member, typename Object, typename... Args>
-    decltype(auto) invoke_helper(Member member, Object &&object, std::true_type, std::true_type,
-                                 std::false_type, Args &&...args)
+    decltype(auto) invoke_helper(Member member, Object &&object,
+                                 std::true_type /* is member pointer */,
+                                 std::true_type /* is member function */,
+                                 std::false_type /* is object a pointer */, Args &&...args)
     {
-        return (object.*member)(std::forward<Args>(args)...);
+        return (std::forward<Object>(object).*member)(std::forward<Args>(args)...);
     }
 
     template <typename Member, typename Object>
-    decltype(auto) invoke_helper(Member member, Object &&object, std::true_type, std::false_type,
-                                 std::false_type)
+    decltype(auto) invoke_helper(Member member, Object &&object,
+                                 std::true_type /* is member pointer */,
+                                 std::false_type /* is member function */,
+                                 std::false_type /* is object a pointer */)
     {
-        return object.*member;
+        return std::forward<Object>(object).*member;
     }
 
     template <typename Function, typename Object, typename... Args>

--- a/src/kdalgorithms.h
+++ b/src/kdalgorithms.h
@@ -14,6 +14,7 @@
 #include "bits/find_if.h"
 #include "bits/generate.h"
 #include "bits/insert_wrapper.h"
+#include "bits/invoke.h"
 #include "bits/method_tests.h"
 #include "bits/operators.h"
 #include "bits/read_iterator_wrapper.h"
@@ -127,18 +128,23 @@ Container sorted(Container container, Compare &&compare = {})
     return container;
 }
 
+enum sort_direction {ascending, descending};
+
 template <typename Container, typename Member>
-void sort_by(Container &container, Member member)
+void sort_by(Container &container, Member member, sort_direction direction = ascending)
 {
-    sort(container, [member](const auto &x, const auto &y) {
-        return x.*member < y.*member;
+    sort(container, [member, direction](const auto &x, const auto &y) {
+        if (direction == ascending)
+            return detail::invoke(member, x) < detail::invoke(member, y);
+        else
+            return detail::invoke(member, x) > detail::invoke(member, y);
     });
 }
 
 template <typename Container, typename Member>
-auto sorted_by(Container container, Member member)
+auto sorted_by(Container container, Member member, sort_direction direction = ascending)
 {
-    sort_by(container, member);
+    sort_by(container, member, direction);
     return container;
 }
 

--- a/tests/tst_kdalgorithms.cpp
+++ b/tests/tst_kdalgorithms.cpp
@@ -2659,21 +2659,21 @@ void TestAlgorithms::invoke()
         QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::go2, getPtr(), 2), 84);
     }
 
-    //    { // move only type
-    //        MoveOnlyStruct foo{42};
-    //        MoveOnlyStruct *ptr = &foo;
-    //        auto func = [](const MoveOnlyStruct &foo) { return foo.x; };
-    //        auto func2 = [](const MoveOnlyStruct &foo, int y) { return foo.x * y; };
+    { // move only type
+        MoveOnlyStruct foo{42};
+        MoveOnlyStruct *ptr = &foo;
+        auto func = [](const MoveOnlyStruct &foo) { return foo.x; };
+        auto func2 = [](const MoveOnlyStruct &foo, int y) { return foo.x * y; };
 
-    //        QCOMPARE(kdalgorithms::detail::invoke(func, foo), 42);
-    //        QCOMPARE(kdalgorithms::detail::invoke(func2, foo, 2), 84);
-    //        QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::x, foo), 42);
-    //        QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::x, ptr), 42);
-    //        QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::go, foo), 42);
-    //        QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::go, ptr), 42);
-    //        QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::go2, foo, 2), 84);
-    //        QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::go2, ptr, 2), 84);
-    //    }
+        QCOMPARE(kdalgorithms::detail::invoke(func, foo), 42);
+        QCOMPARE(kdalgorithms::detail::invoke(func2, foo, 2), 84);
+        QCOMPARE(kdalgorithms::detail::invoke(&MoveOnlyStruct::x, foo), 42);
+        QCOMPARE(kdalgorithms::detail::invoke(&MoveOnlyStruct::x, ptr), 42);
+        QCOMPARE(kdalgorithms::detail::invoke(&MoveOnlyStruct::go, foo), 42);
+        QCOMPARE(kdalgorithms::detail::invoke(&MoveOnlyStruct::go, ptr), 42);
+        QCOMPARE(kdalgorithms::detail::invoke(&MoveOnlyStruct::go2, foo, 2), 84);
+        QCOMPARE(kdalgorithms::detail::invoke(&MoveOnlyStruct::go2, ptr, 2), 84);
+    }
 
     { // l/r-value functions
         InvokableStruct foo{42};
@@ -2683,7 +2683,6 @@ void TestAlgorithms::invoke()
         QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::goL, ptr), 42);
 
         QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::goR, getFoo()), 42);
-        QCOMPARE(kdalgorithms::detail::invoke(&InvokableStruct::goR, getPtr()), 42);
     }
 }
 QTEST_MAIN(TestAlgorithms)


### PR DESCRIPTION
You can now specify a pointer to an object as the first argument. Further, you can use a member function, and a callable as the second parameter.