### PR TITLE
cmake: Add install target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DBUILD_TESTING=ON
           -DKDALGORITHMS_BUILD_TEST=ON
+          -DCMAKE_INSTALL_PREFIX=installed
 
       - name: Build Project (Release)
         run: cmake --build ./build-release
@@ -84,6 +85,15 @@ jobs:
       - name: Run Release tests
         id: tests2
         run: ctest --test-dir ./build-release -C Release --output-on-failure
+
+      - name: Install Project
+        run: cmake --install ./build-release
+
+      - name: Build standalone example against systemwide KDAlgorithms
+        run: |
+          cd tests/test_install
+          cmake -DCMAKE_PREFIX_PATH="../../installed" .
+          cmake --build .
 
       - name: Read tests log when it fails
         uses: andstor/file-reader-action@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,10 @@ endif()
 
 add_library(kdalgorithms INTERFACE)
 add_library(KDAB::KDAlgorithms ALIAS kdalgorithms)
-target_include_directories(kdalgorithms INTERFACE src/)
+target_include_directories(kdalgorithms INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+)
 
 if(MSVC)
     target_compile_options(kdalgorithms INTERFACE /Zc:__cplusplus)
@@ -95,3 +98,51 @@ if(BUILD_TESTING AND ${KDALGORITHMS_BUILD_TEST})
 
     add_subdirectory(Inspiration)
 endif()
+
+install(TARGETS kdalgorithms EXPORT KDAlgorithmsTargets)
+
+install(EXPORT KDAlgorithmsTargets
+    FILE KDAlgorithmsTargets.cmake
+    NAMESPACE KDAB::
+    DESTINATION lib/cmake/KDAlgorithms
+)
+
+install(FILES
+    src/kdalgorithms.h
+    DESTINATION include/kdalgorithms
+)
+
+install(FILES
+    src/kdalgorithms_bits/read_iterator_wrapper.h
+    src/kdalgorithms_bits/find_if.h
+    src/kdalgorithms_bits/filter.h
+    src/kdalgorithms_bits/generate.h
+    src/kdalgorithms_bits/insert_wrapper.h
+    src/kdalgorithms_bits/is_const_method.h
+    src/kdalgorithms_bits/is_detected.h
+    src/kdalgorithms_bits/method_tests.h
+    src/kdalgorithms_bits/operators.h
+    src/kdalgorithms_bits/reserve_helper.h
+    src/kdalgorithms_bits/return_type_trait.h
+    src/kdalgorithms_bits/shared.h
+    src/kdalgorithms_bits/to_function_object.h
+    src/kdalgorithms_bits/transform.h
+    src/kdalgorithms_bits/zip.h
+    src/kdalgorithms_bits/tuple_utils.h
+    src/kdalgorithms_bits/invoke.h
+    src/kdalgorithms_bits/cartesian_product.h
+    DESTINATION include/kdalgorithms/kdalgorithms_bits
+)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    KDAlgorithmsConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/KDAlgorithmsConfig.cmake
+    INSTALL_DESTINATION lib/cmake/KDAlgorithms
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/KDAlgorithmsConfig.cmake
+    DESTINATION lib/cmake/KDAlgorithms
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 project(kdalgorithms
     LANGUAGES CXX
 )

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 project(Example)
 set(CMAKE_CXX_STANDARD 14)
 

--- a/Inspiration/CMakeLists.txt
+++ b/Inspiration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 project(Inspiration)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/KDAlgorithmsConfig.cmake.in
+++ b/KDAlgorithmsConfig.cmake.in
@@ -1,0 +1,4 @@
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/KDAlgorithmsTargets.cmake")

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,7 +4,7 @@ SPDX-PackageSupplier = "<info@kdab.com>"
 SPDX-PackageDownloadLocation = "https://www.github.com/KDAB/KDAlgorithms"
 
 [[annotations]]
-path = ["run", ".gitignore", "CMakeLists.txt", "CMakePresets.json", "README.md", "_clang-format", ".pre-commit-config.yaml", "appveyor.yml", "Documentation/**", "Example/CMakeLists.txt", "Inspiration/CMakeLists.txt", "REUSE.toml"]
+path = ["run", ".gitignore", "CMakeLists.txt", "KDAlgorithmsConfig.cmake.in", "CMakePresets.json", "README.md", "_clang-format", ".pre-commit-config.yaml", "appveyor.yml", "Documentation/**", "Example/CMakeLists.txt", "Inspiration/CMakeLists.txt", "tests/test_install/CMakeLists.txt", "REUSE.toml"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>"
 SPDX-License-Identifier = "MIT"

--- a/tests/test_install/CMakeLists.txt
+++ b/tests/test_install/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Tests that users can use find_package and "link" against KDAlgorithms target
+# This test is built by the GitHub CI workflow
+
+cmake_minimum_required(VERSION 3.10)
+
+project(test_find_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(KDAlgorithms REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE KDAB::kdalgorithms)

--- a/tests/test_install/main.cpp
+++ b/tests/test_install/main.cpp
@@ -1,0 +1,28 @@
+/****************************************************************************
+**
+** This file is part of KDAlgorithms
+**
+** SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+**
+** SPDX-License-Identifier: MIT
+**
+****************************************************************************/
+
+#include <kdalgorithms/kdalgorithms.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main()
+{
+    auto vec = kdalgorithms::iota(1, 100);
+    auto odds = kdalgorithms::filtered(vec, [](int i) { return i % 2 == 1; });
+    auto result = kdalgorithms::accumulate(odds, [](const std::string &partial, int value) {
+        return partial + "," + std::to_string(value);
+    });
+
+    std::cout << result << "\n";
+
+    return 0;
+}


### PR DESCRIPTION
We can now install the headers, which allows KDAlgorithms to be packaged by Brew and other package managers.